### PR TITLE
Make it possible to overwrite csv delimiter & better default delimiter

### DIFF
--- a/src/SprykerEco/Zed/FactFinderSdk/Business/Writer/CsvFileWriter.php
+++ b/src/SprykerEco/Zed/FactFinderSdk/Business/Writer/CsvFileWriter.php
@@ -9,7 +9,7 @@ namespace SprykerEco\Zed\FactFinderSdk\Business\Writer;
 
 class CsvFileWriter extends AbstractFileWriter implements FileWriterInterface
 {
-    const DELIMITER = ',';
+    const DELIMITER = ';';
 
     /**
      * @param string $filePath
@@ -29,7 +29,7 @@ class CsvFileWriter extends AbstractFileWriter implements FileWriterInterface
         }
 
         foreach ($data as $row) {
-            fputcsv($filePointer, $row, self::DELIMITER);
+            fputcsv($filePointer, $row, static::DELIMITER);
         }
 
         fclose($filePointer);


### PR DESCRIPTION
At least for version 7.2 of FactFinder `,` is not an allowed delimiter in the management interface.
Therefore the default should be `;`, which is allowed and it should be overwritable in the project context.

Also, the documentation uses `;` in all examples, so it will avoid confusion during implementation.